### PR TITLE
fix: 프로필 분리로 인한 Bean 중복 오류 해결

### DIFF
--- a/src/main/java/com/team5/capstone/mju/apiserver/web/config/ServerSpringConfig.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/config/ServerSpringConfig.java
@@ -13,7 +13,7 @@ import org.springframework.web.client.RestTemplate;
         @Server(url = "https://mju-2023capstone-team5.run.goorm.site")
 })
 public class ServerSpringConfig {
-    @Bean
+    @Bean(name = "serverRestTemplate")
     public RestTemplate restTemplate() {
         return new RestTemplate();
     }


### PR DESCRIPTION
cors 버그를 잡으려고 프로파일 분리(https://github.com/mju-2023-capstone-team-5/api-server/issues/24) 후 중복 Bean 문제가 생겨 2개의 RestTemplate Bean 중 하나의 Bean 명을 바꿔야 함

서버 프로필의 Bean 명을 수정하였음