### PR TITLE
feat: 주차장 상세 정보 서비스의 더티 체킹을 통한 불필요한 save 호출 제거

### DIFF
--- a/src/main/java/com/team5/capstone/mju/apiserver/web/service/ParkingLotService.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/service/ParkingLotService.java
@@ -46,9 +46,8 @@ public class ParkingLotService {
                 .orElseThrow(() -> new EntityNotFoundException("주차장을 찾을 수 없습니다."));
 
         // 주차장 상세 정보를 업데이트합니다.
-        parkingLot.updateAllInfoSelf(requestDto);
-        ParkingLot updatedParkingLot = parkingLotRepository.save(parkingLot);
-        return ParkingLotResponseDto.of(updatedParkingLot);
+        parkingLot.updateAllInfoSelf(requestDto); // 더티 체킹을 통한 self update
+        return ParkingLotResponseDto.of(parkingLot); // update 된 내용을 기반으로 한 DTO 생성 후 반환
     }
 
     @Transactional


### PR DESCRIPTION
내가 작성한 더티 체킹을 통한 업데이트가 이루어지는 코드 중에 불필요한 save 호출을 제거하고, 엔티티 객체 그 자체를 다시 dto로 변환하여 불필요한 디비 호출 코드 삭제, 납득 가능한 리팩토링 사유를 확인시켜주기 위함 