### PR TITLE
37 회원탈퇴 후처리 api 만들기

### DIFF
--- a/src/main/java/com/team5/capstone/mju/apiserver/web/controller/UserController.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/controller/UserController.java
@@ -1,9 +1,16 @@
 package com.team5.capstone.mju.apiserver.web.controller;
 
 import com.team5.capstone.mju.apiserver.web.service.UserService;
-import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+import javax.websocket.server.PathParam;
 
 @RestController
+@RequestMapping("/api/v1")
+@Tag(name = "유저 컨트롤러", description = "유저 관련 API 요청 controller")
 public class UserController {
 
     private final UserService userService;
@@ -11,4 +18,25 @@ public class UserController {
     public UserController(UserService userService) {
         this.userService = userService;
     }
+
+    @Operation(summary = "사용자 회원탈퇴 후처리 API", description = "사용자의 카카오 회원탈퇴 후 사용자의 정보를 서비스 서버에서 삭제하는 API",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "사용자 정보 삭제에 성공")
+            }
+    )
+    @DeleteMapping("/users/leave")
+    public void deleteUser(@RequestParam("user_id") Long userId) {
+        userService.deleteUser(userId);
+    }
+
+    @Operation(hidden = true, summary = "사용자 회원탈퇴 후처리 API", description = "앱이 아닌 카카오 계정 관리 페이지나 고객센터에서 회원탈퇴 후 사용자의 정보를 서비스 서버에서 삭제하는 API, Kakao Developers에서 설정된 redirect에서 GET/POST 메소드만 제공하기 때문에 Http Method를 GET로 설정",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "사용자 정보 삭제에 성공")
+            }
+    )
+    @GetMapping("/users/leave-kakao") // Kakao Developers에서 설정된 redirect에서 GET/POST 메소드만 제공하기 때문에 Http Method를 GET로 설정
+    public void deleteUserFromKakaoRedirect(@RequestParam("user_id") Long kakaoId) {
+        userService.deleteUserFromKakaoId(kakaoId);
+    }
+
 }

--- a/src/main/java/com/team5/capstone/mju/apiserver/web/service/UserService.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/service/UserService.java
@@ -1,7 +1,11 @@
 package com.team5.capstone.mju.apiserver.web.service;
 
+import com.team5.capstone.mju.apiserver.web.entity.User;
 import com.team5.capstone.mju.apiserver.web.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
 
 @Service
 public class UserService {
@@ -10,5 +14,22 @@ public class UserService {
 
     public UserService(UserRepository userRepository) {
         this.userRepository = userRepository;
+    }
+
+    // 사용자를 삭제하는 메소드
+    @Transactional
+    public void deleteUser(Long id) {
+        User found = userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("해당하는 유저가 없습니다."));
+        userRepository.delete(found);
+    }
+
+    // 사용자를 삭제하는 메소드
+    // 카카오 계정 관리 페이지나 고객센터에서 연결끊기를 진행 시 넘어오는 정보는 kakaoId이기 때문에 kakaoId를 이용한 삭제처리
+    @Transactional
+    public void deleteUserFromKakaoId(Long kakaoId) {
+        User found = userRepository.findByKakaoAppUuid(String.valueOf(kakaoId))
+                .orElseThrow(() -> new EntityNotFoundException("해당하는 카카오 유저가 없습니다."));
+        userRepository.delete(found);
     }
 }


### PR DESCRIPTION
### 구현한 것
회원탈퇴 후 사용자 정보를 삭제하기 위한 후처리 API 구현
- 카카오 SDK를 이용한 회원탈퇴 후 사용자 정보를 삭제하기 위한 API 구현: `/api/v1/users/leave` -> 사용자 id를 받아 삭제
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/38485612/235643483-a6aee154-324c-4b75-8061-8d6a5bb2a6b1.png">

- 앱이 아닌 카카오 계정 관리 페이지나 고객센터에서 회원탈퇴 후 redirect로 사용자 정보를 삭제하게 하는 후처리 API 구현 (API 명세서에 드러나지 않음)
<img width="754" alt="image" src="https://user-images.githubusercontent.com/38485612/235643523-945019b4-1395-45a7-8563-48b787343485.png">
이는 프론트에서 처리하지 않는 API임

### DB 변경점
x