### PR TITLE
feat: 주차장 응답 객체에 imageUrl 및 주차장 id 추가

### DIFF
--- a/src/main/java/com/team5/capstone/mju/apiserver/web/controller/ParkingLotController.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/controller/ParkingLotController.java
@@ -2,6 +2,7 @@ package com.team5.capstone.mju.apiserver.web.controller;
 
 import com.team5.capstone.mju.apiserver.web.dto.ParkingLotDto;
 import com.team5.capstone.mju.apiserver.web.dto.ParkingLotRequestOldDto;
+import com.team5.capstone.mju.apiserver.web.dto.ParkingLotResponseDto;
 import com.team5.capstone.mju.apiserver.web.dto.ParkingLotResponseOldDto;
 import com.team5.capstone.mju.apiserver.web.service.AmazonS3Service;
 import com.team5.capstone.mju.apiserver.web.service.ParkingLotService;
@@ -43,7 +44,7 @@ public class ParkingLotController {
             }
     )
     @GetMapping("/parking-lots/{id}") // HTTP 메소드 별 URL 매핑. localhost:8080/api/v1/parking-lots/1이면 id 변수가 1
-    public ResponseEntity<ParkingLotDto> getParkingLot(@PathVariable("id") Long id) { // url path에 있는 {id}와 변수를 매핑
+    public ResponseEntity<ParkingLotResponseDto> getParkingLot(@PathVariable("id") Long id) { // url path에 있는 {id}와 변수를 매핑
         // 서비스를 호출하여 얻어온 결과값을 반환. 반환 시 json 구조의 String으로 스프링이 해석하여 API 요청에 반환해줌
         return ResponseEntity.ok(parkingLotService.getParkingLotInfo(id));
     }
@@ -60,7 +61,7 @@ public class ParkingLotController {
             }
     )
     @GetMapping("/parking-lots/rectangle")
-    public ResponseEntity<List<ParkingLotDto>> getParkingLotsInDisplay(
+    public ResponseEntity<List<ParkingLotResponseDto>> getParkingLotsInDisplay(
             @RequestParam BigDecimal x1, // 왼쪽 위 위도
             @RequestParam BigDecimal y1, // 왼쪽 위 경도
             @RequestParam BigDecimal x2, // 오른쪽 아래 위도
@@ -75,9 +76,9 @@ public class ParkingLotController {
             }
     )
     @PostMapping("/parking-lots")
-    public ResponseEntity<ParkingLotDto> createParkingLot(@RequestBody ParkingLotDto requestDto) {
+    public ResponseEntity<ParkingLotResponseDto> createParkingLot(@RequestBody ParkingLotDto requestDto) {
         log.info(requestDto.toString());
-        ParkingLotDto responseDto = parkingLotService.createParkingLot(requestDto);
+        ParkingLotResponseDto responseDto = parkingLotService.createParkingLot(requestDto);
         return ResponseEntity.ok(responseDto);
     }
 
@@ -89,7 +90,7 @@ public class ParkingLotController {
     )
     @PostMapping(value = "/parking-lots/{id}/images/info", consumes = {"multipart/form-data"})
     public ResponseEntity<String> uploadParkingLotInfoImage(@PathVariable Long id, @RequestParam(value = "file", required = false) MultipartFile file) {
-        ParkingLotDto parkingLotInfo = parkingLotService.getParkingLotInfo(id);
+        ParkingLotResponseDto parkingLotInfo = parkingLotService.getParkingLotInfo(id);
         String url = amazonS3Service.uploadImage("parking-lots/" + id + "/", "info", file);
         parkingLotService.addImageUrl(id, url);
         return ResponseEntity.ok("upload success");
@@ -103,7 +104,7 @@ public class ParkingLotController {
     )
     @PostMapping(value = "/parking-lots/{id}/images/permit-request", consumes = {"multipart/form-data"})
     public ResponseEntity<String> uploadParkingLotPermitRequestImage(@PathVariable Long id, @RequestParam(value = "file", required = false) MultipartFile[] files) {
-        ParkingLotDto parkingLotInfo = parkingLotService.getParkingLotInfo(id);
+        ParkingLotResponseDto parkingLotInfo = parkingLotService.getParkingLotInfo(id);
         amazonS3Service.uploadImages("parking-lots/" + id + "/permit-req/", "request", files);
         return ResponseEntity.ok("upload success");
     }

--- a/src/main/java/com/team5/capstone/mju/apiserver/web/controller/UserController.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/controller/UserController.java
@@ -2,6 +2,7 @@ package com.team5.capstone.mju.apiserver.web.controller;
 
 import com.team5.capstone.mju.apiserver.web.dto.OwnerResponseDto;
 import com.team5.capstone.mju.apiserver.web.dto.ParkingLotDto;
+import com.team5.capstone.mju.apiserver.web.dto.ParkingLotResponseDto;
 import com.team5.capstone.mju.apiserver.web.dto.UserResponseDto;
 import com.team5.capstone.mju.apiserver.web.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,7 +40,7 @@ public class UserController {
             }
     )
     @GetMapping("/users/{id}/parking-lots") // HTTP 메소드 별 URL 매핑. localhost:8080/api/v1/parking-lots/1이면 id 변수가 1
-    public ResponseEntity<List<ParkingLotDto>> getAllParkingLotBiaOwner(@PathVariable Long id) {
+    public ResponseEntity<List<ParkingLotResponseDto>> getAllParkingLotBiaOwner(@PathVariable Long id) {
         return ResponseEntity.ok(userService.getMyAllParkingLots(id));
     }
 

--- a/src/main/java/com/team5/capstone/mju/apiserver/web/dto/ParkingLotDto.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/dto/ParkingLotDto.java
@@ -1,5 +1,6 @@
 package com.team5.capstone.mju.apiserver.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.team5.capstone.mju.apiserver.web.entity.ParkingAvailableTime;
 import com.team5.capstone.mju.apiserver.web.entity.ParkingLot;
@@ -34,6 +35,12 @@ public class ParkingLotDto {
     private int totalSpace;
     private int remainingSpace;
     private int ownerId;
+
+    @JsonIgnore
+    private String imageUrl;
+
+    @JsonIgnore
+    private Integer id;
 
     @JsonProperty(value = "type")
     private String[] type;
@@ -159,12 +166,14 @@ public class ParkingLotDto {
         });
 
         return ParkingLotDto.builder()
+                .id(Math.toIntExact(parkingLot.getParkingLotId()))
                 .name(parkingLot.getName())
                 .address(parkingLot.getAddress())
                 .freeInformation(parkingLot.getFreeInformation())
                 .latitude(parkingLot.getLatitude())
                 .longitude(parkingLot.getLongitude())
                 .totalSpace(parkingLot.getTotalSpace())
+                .imageUrl(parkingLot.getImageUrl())
                 .remainingSpace(parkingLot.getRemainingSpace())
                 .ownerId(owner.getOwnerId())
                 .phoneNumber(owner.getInquiryPhoneNumber())

--- a/src/main/java/com/team5/capstone/mju/apiserver/web/dto/ParkingLotResponseDto.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/dto/ParkingLotResponseDto.java
@@ -1,0 +1,76 @@
+package com.team5.capstone.mju.apiserver.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.team5.capstone.mju.apiserver.web.vo.ParkingLotPrice;
+import com.team5.capstone.mju.apiserver.web.vo.ParkingLotTime;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@ToString
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ParkingLotResponseDto {
+
+    private String name;
+    private String address;
+    private String freeInformation;
+    private String phoneNumber;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    private int totalSpace;
+    private int remainingSpace;
+    private int ownerId;
+
+    // ParkingLotDto에서는 jsonIgnore 속성으로 요청/응답에서 보이지 않지만
+    // 응답 객체로 반환할 때 of 함수에서 대입한 id 값을 @JsonProperty로 공개하여 응답 데이터에서 공개
+    @JsonProperty(value = "id")
+    private Integer id;
+
+    // ParkingLotDto에서는 jsonIgnore 속성으로 요청/응답에서 보이지 않지만
+    // 응답 객체로 반환할 때 of 함수에서 대입한 id 값을 @JsonProperty로 공개하여 응답 데이터에서 공개
+    @JsonProperty(value = "imageUrl")
+    private String imageUrl;
+
+    @JsonProperty(value = "type")
+    private String[] type;
+
+    @JsonProperty(value = "availableDay")
+    private String[] availableDay;
+
+    @JsonProperty(value = "availableTime")
+    private ParkingLotTime[] time;
+
+    @JsonProperty(value = "monthly", required = false)
+    private ParkingLotPrice monthPrice;
+
+    @JsonProperty(value = "hourly", required = false)
+    private ParkingLotPrice hourPrice;
+
+    public static ParkingLotResponseDto of(ParkingLotDto parkingLotDto) {
+
+        return ParkingLotResponseDto.builder()
+                .id(parkingLotDto.getId()) // 응답 데이터로 추가
+                .name(parkingLotDto.getName())
+                .address(parkingLotDto.getAddress())
+                .freeInformation(parkingLotDto.getFreeInformation())
+                .latitude(parkingLotDto.getLatitude())
+                .longitude(parkingLotDto.getLongitude())
+                .totalSpace(parkingLotDto.getTotalSpace())
+                .imageUrl(parkingLotDto.getImageUrl())
+                .remainingSpace(parkingLotDto.getRemainingSpace())
+                .ownerId(parkingLotDto.getOwnerId())
+                .phoneNumber(parkingLotDto.getPhoneNumber())
+                .availableDay(parkingLotDto.getAvailableDay())
+                .type(parkingLotDto.getType())
+                .monthPrice(parkingLotDto.getMonthPrice())
+                .hourPrice(parkingLotDto.getHourPrice())
+                .time(parkingLotDto.getTime())
+                .imageUrl(parkingLotDto.getImageUrl()) // 응답 데이터로 추가
+                .build();
+    }
+
+}

--- a/src/main/java/com/team5/capstone/mju/apiserver/web/service/ParkingLotService.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/service/ParkingLotService.java
@@ -2,6 +2,7 @@ package com.team5.capstone.mju.apiserver.web.service;
 
 import com.team5.capstone.mju.apiserver.web.dto.ParkingLotDto;
 import com.team5.capstone.mju.apiserver.web.dto.ParkingLotRequestOldDto;
+import com.team5.capstone.mju.apiserver.web.dto.ParkingLotResponseDto;
 import com.team5.capstone.mju.apiserver.web.dto.ParkingLotResponseOldDto;
 import com.team5.capstone.mju.apiserver.web.entity.*;
 import com.team5.capstone.mju.apiserver.web.enums.ParkingLotPriceType;
@@ -43,7 +44,7 @@ public class ParkingLotService {
     }
 
     @Transactional(readOnly = true)
-    public ParkingLotDto getParkingLotInfo(Long id) {
+    public ParkingLotResponseDto getParkingLotInfo(Long id) {
         ParkingLot found = parkingLotRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("주차장을 찾을 수 없습니다."));
 
@@ -51,11 +52,11 @@ public class ParkingLotService {
         List<ParkingAvailableTime> availableTimeList = availableTimeRepository.findAllByParkingLotId(Math.toIntExact(id));
         List<ParkingPrice> priceList = priceRepository.findAllByParkingLotId(Math.toIntExact(id));
 
-        return ParkingLotDto.of(found, owner, availableTimeList, priceList);
+        return ParkingLotResponseDto.of(ParkingLotDto.of(found, owner, availableTimeList, priceList));
     }
 
     @Transactional(readOnly = true)
-    public List<ParkingLotDto> getParkingLotsInRectangle(BigDecimal x1, BigDecimal y1, BigDecimal x2, BigDecimal y2) {
+    public List<ParkingLotResponseDto> getParkingLotsInRectangle(BigDecimal x1, BigDecimal y1, BigDecimal x2, BigDecimal y2) {
         List<ParkingLot> all = parkingLotRepository.findAll();
 
         List<ParkingLot> found = all.stream()
@@ -64,7 +65,7 @@ public class ParkingLotService {
                 })
                 .collect(Collectors.toList());
 
-        List<ParkingLotDto> resultDtos = new ArrayList<>();
+        List<ParkingLotResponseDto> resultDtos = new ArrayList<>();
 
         found.forEach(parkingLot -> {
             resultDtos.add(getParkingLotInfo(parkingLot.getParkingLotId()));
@@ -75,7 +76,7 @@ public class ParkingLotService {
 
     // 주차장 생성
     @Transactional
-    public ParkingLotDto createParkingLot(ParkingLotDto requestDto) {
+    public ParkingLotResponseDto createParkingLot(ParkingLotDto requestDto) {
 
         User ownerUser = userRepository.findById(Long.valueOf(requestDto.getOwnerId()))
                 .orElseThrow(() -> new EntityNotFoundException("주차장 주인 사용자가 존재하지 않습니다."));
@@ -114,7 +115,7 @@ public class ParkingLotService {
         });
         availableTimeRepository.saveAll(availableTimeList);
 
-        return requestDto;
+        return getParkingLotInfo(saved.getParkingLotId());
     }
 
     // 주차장 업데이트

--- a/src/main/java/com/team5/capstone/mju/apiserver/web/service/UserService.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/service/UserService.java
@@ -2,6 +2,7 @@ package com.team5.capstone.mju.apiserver.web.service;
 
 import com.team5.capstone.mju.apiserver.web.dto.OwnerResponseDto;
 import com.team5.capstone.mju.apiserver.web.dto.ParkingLotDto;
+import com.team5.capstone.mju.apiserver.web.dto.ParkingLotResponseDto;
 import com.team5.capstone.mju.apiserver.web.dto.UserResponseDto;
 import com.team5.capstone.mju.apiserver.web.entity.ParkingLotOwner;
 import com.team5.capstone.mju.apiserver.web.entity.User;
@@ -65,13 +66,13 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public List<ParkingLotDto> getMyAllParkingLots(Long id) {
+    public List<ParkingLotResponseDto> getMyAllParkingLots(Long id) {
         User found = userRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
 
         List<ParkingLotOwner> all = ownerRepository.findAllByOwnerId(Math.toIntExact(id));
 
-        List<ParkingLotDto> resultDtos = new ArrayList<>();
+        List<ParkingLotResponseDto> resultDtos = new ArrayList<>();
 
         all.forEach(owner -> {
             resultDtos.add(parkingLotService.getParkingLotInfo(Long.valueOf(owner.getParkingLotId())));


### PR DESCRIPTION
### 개선한 서비스
주차장 응답 객체에 imageUrl 및 생성된 주차장 id 추가
- 기존에 통합으로 사용하던 요청/응답 DTO를 수정 시 요청 데이터에도 imageUrl 및 주차장 id를 사용해야 하므로 요청 객체/응답 객체를 분리해야 하는 필요가 생김 -> 통합 DTO에서 JsonIgnore 프로퍼티로 imageUrl 및 주차장id를 가지며, of() 메소드를 통해 응답 객체로 생성될 때 삽입되어 가지게 함 -> 같은 속성을 가진 DTO 객체를 만들고 JsonIgnore 속성을 JsonProperty 속성으로 변경 후 of 함수로 기존 통합 DTO가 가진 imageUrl과 주차장id를 가지게 하며 응답 데이터에 노출되게 함

### 요약
요청 스펙을 변경하지 않으면서 응답 데이터에 노출되게 변경
참조: https://github.com/mju-2023-capstone-team-5/api-server/issues/58

![이미지 2023  5  13  오전 12 35](https://github.com/mju-2023-capstone-team-5/api-server/assets/38485612/0df90c48-b349-46e5-b1aa-288505e58d9f)

