### PR TITLE
fix: 주차장을 삭제 시 owner이 같이 삭제되지 않아 owner로 주차장을 조회하는 코드 호출 시 에러가 나는 점 수정

### DIFF
--- a/src/main/java/com/team5/capstone/mju/apiserver/web/service/ParkingLotService.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/service/ParkingLotService.java
@@ -192,6 +192,12 @@ public class ParkingLotService {
     public void deleteParkingLot(Long id) {
         ParkingLot found = parkingLotRepository.findById(id)
                 .orElseThrow(() -> new ParkingLotNotFoundException(id));
+
+        ParkingLotOwner foundOwner = ownerRepository.findById(Long.valueOf(found.getOwnerId()))
+                .orElseThrow(() -> new OwnerNotFoundException(found.getOwnerId()));
+
+        ownerRepository.delete(foundOwner);
+
         parkingLotRepository.delete(found);
     }
 


### PR DESCRIPTION
### 개발한 서비스
버그 수정: 주차장 삭제 시 owner을 추가로 삭제하지 않아 문제가 발생하는 현상
참조: https://github.com/mju-2023-capstone-team-5/api-server/issues/85

주차장 삭제 시 주차장이 참조하는 owner를 같이 삭제 해 주차장 정보를 가지는 owner 정보가 존재하지 않게 수정함