### PR TITLE
간헐적으로 데이터베이스에 한글이 깨져서 들어가는 문제 - spring http encoding 설정 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,11 @@ spring:
     charset: UTF-8
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER
+  http:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect # mysql 버전을 따라가는 Hibernate 구현체 문법 설정
     hibernate:


### PR DESCRIPTION
참조: https://github.com/mju-2023-capstone-team-5/api-server/issues/91
블로그를 참고하여 spring http 인코딩 설정도 추가