### PR TITLE
간헐적으로 데이터베이스에 한글이 깨져서 들어가는 문제 - 데이터 타입 변경 적용

### DIFF
--- a/src/main/java/com/team5/capstone/mju/apiserver/web/controller/ParkingLotController.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/controller/ParkingLotController.java
@@ -79,7 +79,7 @@ public class ParkingLotController {
     )
     @PostMapping("/parking-lots")
     public ResponseEntity<ParkingLotResponseDto> createParkingLot(@RequestBody ParkingLotDto requestDto) {
-        log.info(requestDto.toString());
+        log.info("POST /api/v1/parking-lots | DTO: " + requestDto.toString());
         ParkingLotResponseDto responseDto = parkingLotService.createParkingLot(requestDto);
         return ResponseEntity.ok(responseDto);
     }

--- a/src/main/java/com/team5/capstone/mju/apiserver/web/entity/ParkingLot.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/entity/ParkingLot.java
@@ -48,12 +48,10 @@ public class ParkingLot {
     @Column(name = "owner_id")
     private Integer ownerId;
 
-    @Lob
-    @Column(name = "car_type", columnDefinition = "text")
+    @Column(name = "car_type")
     private String carType;
 
-    @Lob
-    @Column(name = "available_day", columnDefinition = "text")
+    @Column(name = "available_day")
     private String availableDay;
 
     public void updateAllInfoSelf(ParkingLotRequestOldDto requestDto) {


### PR DESCRIPTION
참조: https://github.com/mju-2023-capstone-team-5/api-server/issues/91
feat: 한글이 깨지는 속성 두 개를 varchar로 변경, logging 추가

주차장 테이블의 text 데이터 타입을 가지는 속성 두 개를 varchar로 변경

```sql
ALTER TABLE share_our_parking_lot_dev.parking_lot MODIFY COLUMN car_type varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL;
ALTER TABLE share_our_parking_lot_dev.parking_lot MODIFY COLUMN available_day varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL;
```
