### PR TITLE
간헐적으로 데이터베이스에 한글이 깨져서 들어가는 문제 - 모든 text 속성을 varchar로 변경

### DIFF
--- a/src/main/java/com/team5/capstone/mju/apiserver/web/entity/Announcement.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/entity/Announcement.java
@@ -17,12 +17,10 @@ public class Announcement {
     @Column(name = "announcement_id", nullable = false, columnDefinition = "int")
     private Long announcementId;
 
-    @Lob
-    @Column(name = "title", columnDefinition = "TEXT")
+    @Column(name = "title")
     private String title;
 
-    @Lob
-    @Column(name = "content", columnDefinition = "TEXT")
+    @Column(name = "content")
     private String content;
 
     @Column(name = "timestamp")

--- a/src/main/java/com/team5/capstone/mju/apiserver/web/entity/Declaration.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/entity/Declaration.java
@@ -22,8 +22,7 @@ public class Declaration {
     @Column(name = "declaration_time")
     private LocalDateTime declarationTime;
 
-    @Lob
-    @Column(name = "declaration_detail", columnDefinition = "TEXT")
+    @Column(name = "declaration_detail")
     private String declarationDetail;
 
 }

--- a/src/main/java/com/team5/capstone/mju/apiserver/web/entity/Faq.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/entity/Faq.java
@@ -16,12 +16,11 @@ public class Faq {
     @Column(name = "faq_id", nullable = false, columnDefinition = "int")
     private Long faqId;
 
-    @Column(name = "question", columnDefinition = "TEXT")
-    @Lob // Text 타입을 매칭할 때 사용, 뜻은: Large object
+    @Column(name = "question")
+    //@Lob // Text 타입을 매칭할 때 사용, 뜻은: Large object
     private String question;
 
-    @Lob
-    @Column(name = "answer", columnDefinition = "TEXT")
+    @Column(name = "answer")
     private String answer;
 
 }

--- a/src/main/java/com/team5/capstone/mju/apiserver/web/entity/Grade.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/entity/Grade.java
@@ -26,8 +26,7 @@ public class Grade {
     @Column(name = "rating")
     private Float rating;
 
-    @Lob
-    @Column(name = "comment", columnDefinition = "TEXT")
+    @Column(name = "comment")
     private String comment;
 
     @Column(name = "timestamp")

--- a/src/main/java/com/team5/capstone/mju/apiserver/web/entity/Notification.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/entity/Notification.java
@@ -19,8 +19,7 @@ public class Notification {
     @Column(name = "user_id")
     private Integer userId;
 
-    @Lob
-    @Column(name = "content", columnDefinition = "TEXT")
+    @Column(name = "content")
     private String content;
 
     @Column(name = "date_sent")

--- a/src/main/java/com/team5/capstone/mju/apiserver/web/entity/ParkingLot.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/entity/ParkingLot.java
@@ -48,10 +48,10 @@ public class ParkingLot {
     @Column(name = "owner_id")
     private Integer ownerId;
 
-    @Column(name = "car_type")
+    @Column(name = "car_type", columnDefinition = "varchar(255)")
     private String carType;
 
-    @Column(name = "available_day")
+    @Column(name = "available_day", columnDefinition = "varchar(255)")
     private String availableDay;
 
     public void updateAllInfoSelf(ParkingLotRequestOldDto requestDto) {

--- a/src/main/java/com/team5/capstone/mju/apiserver/web/entity/Qna.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/entity/Qna.java
@@ -24,12 +24,10 @@ public class Qna {
     @Column(name = "title")
     private String title;
 
-    @Lob
-    @Column(name = "content", columnDefinition = "TEXT")
+    @Column(name = "content")
     private String content;
 
-    @Lob
-    @Column(name = "answer", columnDefinition = "TEXT")
+    @Column(name = "answer")
     private String answer;
 
     @Column(name = "date_asked")

--- a/src/main/java/com/team5/capstone/mju/apiserver/web/entity/Reservation.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/entity/Reservation.java
@@ -39,8 +39,7 @@ public class Reservation {
     @Column(name = "date_type")
     private String dateType;
 
-    @Lob
-    @Column(name = "pay_receipt_ids", columnDefinition = "TEXT")
+    @Column(name = "pay_receipt_ids")
     private String payReceiptIds;
 
     @Column(name = "is_returned")

--- a/src/main/java/com/team5/capstone/mju/apiserver/web/entity/UserPayReceipt.java
+++ b/src/main/java/com/team5/capstone/mju/apiserver/web/entity/UserPayReceipt.java
@@ -21,8 +21,7 @@ public class UserPayReceipt {
     @Column(name = "amount")
     private Long amount;
 
-    @Lob
-    @Column(name = "payment_type", columnDefinition = "TEXT")
+    @Column(name = "payment_type")
     private String paymentType;
 
 }


### PR DESCRIPTION
참조: https://github.com/mju-2023-capstone-team-5/api-server/issues/91
feat: 다른 모든 entity의 text 데이터 타입을 가지는 속성의 타입을 varchar로 변경함에 따라 @Lob와 columnDefinition 삭제

sql:
```sql
ALTER TABLE share_our_parking_lot_dev.announcement MODIFY COLUMN title varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL;
ALTER TABLE share_our_parking_lot_dev.announcement MODIFY COLUMN content varchar(510) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL;

ALTER TABLE share_our_parking_lot_dev.declaration MODIFY COLUMN declaration_detail varchar(510) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL;

ALTER TABLE share_our_parking_lot_dev.faq MODIFY COLUMN question varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL;
ALTER TABLE share_our_parking_lot_dev.faq MODIFY COLUMN answer varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL;

ALTER TABLE share_our_parking_lot_dev.grade MODIFY COLUMN comment varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL;

ALTER TABLE share_our_parking_lot_dev.notification MODIFY COLUMN content varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL;

ALTER TABLE share_our_parking_lot_dev.qna MODIFY COLUMN content varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL;
ALTER TABLE share_our_parking_lot_dev.qna MODIFY COLUMN answer varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL;

ALTER TABLE share_our_parking_lot_dev.reservation MODIFY COLUMN pay_receipt_ids varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL;

ALTER TABLE share_our_parking_lot_dev.user_pay_receipt MODIFY COLUMN payment_type varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL;
```